### PR TITLE
fix: use npm install in workflow

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --no-fund
+        run: npm install --no-audit --no-fund
 
       - name: Install Playwright
         run: npx playwright install --with-deps


### PR DESCRIPTION
## Summary
- replace npm ci with npm install in GitHub Actions workflow to avoid missing lockfile errors

## Testing
- `npm test` *(fails: Missing script: "test" )*


------
https://chatgpt.com/codex/tasks/task_e_689a7cb9a730832da677144c504e3bfa