### PR TITLE
Preserve existing gh-pages content

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -49,3 +49,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
           publish_branch: gh-pages
+          keep_files: true


### PR DESCRIPTION
## Summary
- Prevent gh-pages deployments from removing previous files by enabling `keep_files` in the workflow

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689af12066c8832dbde8b358769c0225