### PR TITLE
chore: temporarily disable scheduled scrape

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,7 +1,7 @@
 name: Scrape Biwenger
 on:
-  schedule:
-    - cron: '0 5 * * *'   # 07:00 hora España
+  # schedule:
+  #   - cron: '0 5 * * *'   # 07:00 hora España
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Summary
- disable scheduled run of scrape workflow by commenting cron

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68aabf59a7b4832d87d70a8777d7893b