### PR TITLE
Add clause unlock fields to profile enrichment

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -288,7 +288,15 @@ async function enrichFromProfile(context, players, concurrency = 5) {
               ownerUrl = ownerLink.getAttribute('href') || null;
             }
 
-            return { clause, clauseDeposited, owner, ownerUrl };
+            // Cláusula desbloqueada (si existe)
+            let clauseUnlockAt = null, clauseUnlockIn = null;
+            const unlockNode = document.querySelector('div:has-text("Cláusula desbloqueada") time-relative');
+            if (unlockNode) {
+              clauseUnlockAt = unlockNode.getAttribute('title') || null;
+              clauseUnlockIn = C(unlockNode.textContent || '');
+            }
+
+            return { clause, clauseDeposited, owner, ownerUrl, clauseUnlockAt, clauseUnlockIn };
           });
 
           out[i] = { ...out[i], ...details };


### PR DESCRIPTION
## Summary
- capture clause unlock timestamp and remaining time when enriching player profiles

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af4df3498c832d940b3c3933ddb0e3