### PR TITLE
Calcula dias restantes para desbloquear clausula

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -297,9 +297,33 @@ async function enrichFromProfile(context, players, concurrency = 5) {
             }
 
             return { clause, clauseDeposited, owner, ownerUrl, clauseUnlockAt, clauseUnlockIn };
-          });
+          }).catch(() => ({}));
 
-          out[i] = { ...out[i], ...details };
+          // calcular días restantes para desbloquear la cláusula
+          let clauseUnlockDays = null;
+          if (details.clauseUnlockAt) {
+            const m = details.clauseUnlockAt.match(/(\d{1,2})\/(\d{1,2})\/(\d{2,4}),\s*(\d{1,2}):(\d{2})/);
+            if (m) {
+              let [ , d, mo, y, h, mi ] = m;
+              const year = y.length === 2 ? 2000 + Number(y) : Number(y);
+              const date = new Date(year, Number(mo)-1, Number(d), Number(h), Number(mi));
+              const diff = date.getTime() - Date.now();
+              if (!isNaN(diff)) clauseUnlockDays = Math.ceil(diff / (1000 * 60 * 60 * 24));
+            }
+          }
+
+          out[i] = {
+            clause: null,
+            clauseDeposited: null,
+            owner: null,
+            ownerUrl: null,
+            clauseUnlockAt: null,
+            clauseUnlockIn: null,
+            clauseUnlockDays: null,
+            ...out[i],
+            ...details,
+            clauseUnlockDays
+          };
         } catch { /* continuar con el resto */ }
       }
     } finally {


### PR DESCRIPTION
## Summary
- Calcula y agrega `clauseUnlockDays` a cada jugador, garantizando tambien la presencia de campos de clausula y propietario

## Testing
- `npm test` (falla: Missing script "test")
- `npm start` (falla: Faltan BIWENGER_EMAIL, BIWENGER_PASSWORD o LIGA_ID)


------
https://chatgpt.com/codex/tasks/task_e_68af7c6be1c4832d8ea75e4505e293e9