### PR TITLE
Capture clause unlock message from player profile

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -289,14 +289,14 @@ async function enrichFromProfile(context, players, concurrency = 5) {
             }
 
             // Cláusula desbloqueada (si existe)
-            /*let clauseUnlockAt = null, clauseUnlockIn = null;
-            const unlockNode = document.querySelector('div:has-text("Cláusula desbloqueada") time-relative');
-            if (unlockNode) {
-              clauseUnlockAt = unlockNode.getAttribute('title') || null;
-              clauseUnlockIn = C(unlockNode.textContent || '');
-            }*/
+            let clauseUnlockIn = null;
+            const clauseNode = document.querySelector('player-clause[title*="Cláusula desbloqueada"]');
+            if (clauseNode) {
+              const title = clauseNode.getAttribute('title') || '';
+              clauseUnlockIn = C(title.replace(/Cláusula desbloqueada en/i, ''));
+            }
 
-            return { clause, clauseDeposited, owner, ownerUrl/*, clauseUnlockAt, clauseUnlockIn */};
+            return { clause, clauseDeposited, owner, ownerUrl, clauseUnlockIn };
           });
 
           out[i] = {


### PR DESCRIPTION
## Summary
- capture player clause unlock message from player profile

## Testing
- `npm test` (fails: Missing script: "test")
- `node src/run.js` (fails: Faltan BIWENGER_EMAIL, BIWENGER_PASSWORD o LIGA_ID)


------
https://chatgpt.com/codex/tasks/task_e_68b1f1a73a3c832db9ecaf618371d486