### PR TITLE
chore: run scraper on main run.js changes

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -2,8 +2,9 @@ name: Scrape Biwenger
 on:
   # schedule:
   #   - cron: '0 5 * * *'   # 07:00 hora España
-  workflow_dispatch: {}
   push:
+    branches:
+      - main
     paths:
       - 'src/run.js'
       #- '**/*.yml'


### PR DESCRIPTION
## Summary
- run workflow only when src/run.js is modified on main branch

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b32c2cfa88832d80fe4e25aaf4a174