### PR TITLE
fix: ensure owner name extracted

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -284,7 +284,12 @@ async function enrichFromProfile(context, players, concurrency = 5) {
             const ownerLink = document.querySelector('div:has(> user-link) a[href^="/user/"]') ||
                               document.querySelector('a[href^="/user/"]');
             if (ownerLink) {
-              owner = C(ownerLink.textContent);
+              const ownerText = ownerLink.textContent ||
+                                ownerLink.getAttribute('aria-label') ||
+                                ownerLink.getAttribute('title') ||
+                                ownerLink.querySelector('img')?.getAttribute('alt');
+              const cleaned = C(ownerText || '');
+              owner = cleaned || null;
               ownerUrl = ownerLink.getAttribute('href') || null;
             }
 


### PR DESCRIPTION
## Summary
- ensure owner name is captured from player profile by checking text and fallback attributes

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check src/run.js`


------
https://chatgpt.com/codex/tasks/task_e_68b330bdcedc832da3b405440213b9e9