### PR TITLE
Programar workflow a las 7:00 Madrid

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,7 +1,7 @@
 name: Scrape Biwenger
 on:
-  # schedule:
-  #   - cron: '0 5 * * *'   # 07:00 hora España
+  schedule:
+    - cron: '0 5 * * 1,3,4,5'   # 07:00 Europe/Madrid
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Ejecutar el workflow `scrape.yml` a las 07:00 (hora Madrid) los lunes, miércoles, jueves y viernes

## Testing
- `npm test` *(falla: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b928f2f5c8832db38601adcca48049